### PR TITLE
Added extra property for moving cell.

### DIFF
--- a/TGLStackedViewController/TGLExposedLayout.h
+++ b/TGLStackedViewController/TGLExposedLayout.h
@@ -51,6 +51,12 @@
 /** Amount of overlap for items below exposed item. Default 20.0 */
 @property (assign, nonatomic) CGFloat bottomOverlap;
 
+/** Max number of top overlapping items visible to user. 0 = no limit. This will depends on topOverlap, e.g. visible height per item = topOverlap ÷ maxTopVisibleItems. Default 1 */
+@property (assign, nonatomic) NSInteger maxTopVisibleItems;
+
+/** Max number of bottom overlapping items visible to user. 0 = no limit. This will depends on bottomOverlap, e.g. visible height per item = bottomOverlap ÷ maxBottomVisibleItems. Default 1 */
+@property (assign, nonatomic) NSInteger maxBottomVisibleItems;
+
 - (instancetype)initWithExposedItemIndex:(NSInteger)exposedItemIndex;
 
 @end

--- a/TGLStackedViewController/TGLStackedLayout.h
+++ b/TGLStackedViewController/TGLStackedLayout.h
@@ -59,6 +59,12 @@
 /** Index path of item currently being moved, and thus being hidden */
 @property (strong, nonatomic) NSIndexPath *movingIndexPath;
 
+/** Top visible overlapping height per card in stack. Default is 0.0 */
+@property (assign, nonatomic) CGFloat topVisibleOverlappingHeight;
+
+/** Max number of overlapping cards visible to user. 0 = no limit. This will only take effect if topVisibleOverlappingHeight is not 0. Default is 0 */
+@property (assign, nonatomic) NSInteger maxTopVisibleOverlappingCards;
+
 /** Check if layout needs update for new moving location.
  *
  * This method is called by the view controller, when an item

--- a/TGLStackedViewController/TGLStackedLayout.m
+++ b/TGLStackedViewController/TGLStackedLayout.m
@@ -61,6 +61,8 @@
     self.layoutMargin = UIEdgeInsetsMake(20.0, 0.0, 0.0, 0.0);
     self.topReveal = 120.0;
     self.bounceFactor = 0.2;
+    self.topVisibleOverlappingHeight = 0.f;
+    self.maxTopVisibleOverlappingCards = 0;
 }
 
 #pragma mark - Accessors
@@ -233,7 +235,11 @@
             //
             CGRect frame = attributes.frame;
             
-            frame.origin.y = contentOffset.y + self.layoutMargin.top;
+            CGFloat margin = (self.maxTopVisibleOverlappingCards > 0)
+                ? (MIN(overlappingCount, self.maxTopVisibleOverlappingCards+ 1) * self.topVisibleOverlappingHeight)
+                : overlappingCount * self.topVisibleOverlappingHeight;
+            
+            frame.origin.y = contentOffset.y + self.layoutMargin.top + margin;
             
             attributes.frame = frame;
             

--- a/TGLStackedViewController/TGLStackedLayout.m
+++ b/TGLStackedViewController/TGLStackedLayout.m
@@ -236,7 +236,7 @@
             CGRect frame = attributes.frame;
             
             CGFloat margin = (self.maxTopVisibleOverlappingCards > 0)
-                ? (MIN(overlappingCount, self.maxTopVisibleOverlappingCards+ 1) * self.topVisibleOverlappingHeight)
+                ? (MIN(overlappingCount, self.maxTopVisibleOverlappingCards) * self.topVisibleOverlappingHeight)
                 : overlappingCount * self.topVisibleOverlappingHeight;
             
             frame.origin.y = contentOffset.y + self.layoutMargin.top + margin;

--- a/TGLStackedViewController/TGLStackedViewController.h
+++ b/TGLStackedViewController/TGLStackedViewController.h
@@ -152,4 +152,24 @@
  */
 - (void)moveItemAtIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath;
 
+/** Action before item expose
+ *
+ * Overload this method to add any action
+ * before the item expose
+ *
+ * @param indexPath Item indexPath
+ * @param exposed YES if is being exposed; NO otherwise
+ */
+- (void)exposeBeginAtIndexPath:(NSIndexPath *)indexPath exposed:(BOOL)exposed;
+
+/** Action after item expose
+ *
+ * Overload this method to add any action
+ * after the item expose
+ *
+ * @param indexPath Item indexPath
+ * @param exposed YES if is being exposed; NO otherwise
+ */
+- (void)exposeEndedAtIndexPath:(NSIndexPath *)indexPath exposed:(BOOL)exposed;
+
 @end

--- a/TGLStackedViewController/TGLStackedViewController.h
+++ b/TGLStackedViewController/TGLStackedViewController.h
@@ -91,6 +91,14 @@
  */
 @property (assign, nonatomic) BOOL unexposedItemsAreSelectable;
 
+/** Whether or not to set the moving cell opaque
+ * to be tapped and thus select another item.
+ *
+ * If set to NO (default), the moving cell background
+ * will be transparent.
+ */
+@property (assign, nonatomic) BOOL movingCellOpaque;
+
 /** Check whether a given cell can be moved.
  *
  * Overload this method to prevent items from

--- a/TGLStackedViewController/TGLStackedViewController.h
+++ b/TGLStackedViewController/TGLStackedViewController.h
@@ -59,6 +59,15 @@
  */
 @property (assign, nonatomic) CGFloat exposedTopOverlap;
 
+/** Total number of visible items above exposed item.
+ *
+ * Changes to this property take effect on next
+ * item being selected, i.e. exposed.
+ *
+ * Default value is 1
+ */
+@property (assign, nonatomic) CGFloat exposedMaxTopVisibleItems;
+
 /** Amount of overlap for items below exposed item.
  *
  * Changes to this property take effect on next
@@ -67,6 +76,15 @@
  * Default value is 20.0
  */
 @property (assign, nonatomic) CGFloat exposedBottomOverlap;
+
+/** Total number of visible items below exposed item.
+ *
+ * Changes to this property take effect on next
+ * item being selected, i.e. exposed.
+ *
+ * Default value is 1
+ */
+@property (assign, nonatomic) CGFloat exposedMaxBottomVisibleItems;
 
 /** Index path of currently exposed item.
  *

--- a/TGLStackedViewController/TGLStackedViewController.m
+++ b/TGLStackedViewController/TGLStackedViewController.m
@@ -154,16 +154,16 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
             exposedLayout.maxTopVisibleItems = self.exposedMaxTopVisibleItems;
             exposedLayout.maxBottomVisibleItems = self.exposedMaxBottomVisibleItems;
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0
-            [self.collectionView setCollectionViewLayout:exposedLayout animated:YES completion:^(BOOL finished) {
-                if (finished) {
-                    [weakSelf exposeEndedAtIndexPath:exposedItemIndexPath exposed:YES];
-                }
-            }];
-#else
-            [self.collectionView setCollectionViewLayout:exposedLayout animated:YES];
-            [self exposeEndedAtIndexPath:exposedItemIndexPath exposed:YES];
-#endif
+            if ([self.collectionView respondsToSelector:@selector(setCollectionViewLayout:animated:completion:)]) {
+                [self.collectionView setCollectionViewLayout:exposedLayout animated:YES completion:^(BOOL finished) {
+                    if (finished) {
+                        [weakSelf exposeEndedAtIndexPath:exposedItemIndexPath exposed:YES];
+                    }
+                }];
+            } else {
+                [self.collectionView setCollectionViewLayout:exposedLayout animated:YES];
+                [self exposeEndedAtIndexPath:exposedItemIndexPath exposed:YES];
+            }
             
         } else {
             NSIndexPath *lastIndexPath = _exposedItemIndexPath;
@@ -177,16 +177,16 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
             self.stackedLayout.overwriteContentOffset = YES;
             self.stackedLayout.contentOffset = self.stackedContentOffset;
             
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0
-            [self.collectionView setCollectionViewLayout:self.stackedLayout animated:YES completion:^(BOOL finished) {
-                if (finished) {
-                    [weakSelf exposeEndedAtIndexPath:lastIndexPath exposed:NO];
-                }
-            }];
-#else
-            [self.collectionView setCollectionViewLayout:self.stackedLayout animated:YES];
-            [self exposeEndedAtIndexPath:lastIndexPath exposed:NO];
-#endif
+            if ([self.collectionView respondsToSelector:@selector(setCollectionViewLayout:animated:completion:)]) {
+                [self.collectionView setCollectionViewLayout:self.stackedLayout animated:YES completion:^(BOOL finished) {
+                    if (finished) {
+                        [weakSelf exposeEndedAtIndexPath:lastIndexPath exposed:NO];
+                    }
+                }];
+            } else {
+                [self.collectionView setCollectionViewLayout:self.stackedLayout animated:YES];
+                [self exposeEndedAtIndexPath:lastIndexPath exposed:NO];
+            }
             [self.collectionView setContentOffset:self.stackedContentOffset animated:NO];
         }
         

--- a/TGLStackedViewController/TGLStackedViewController.m
+++ b/TGLStackedViewController/TGLStackedViewController.m
@@ -187,6 +187,11 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
                 [self.collectionView setCollectionViewLayout:self.stackedLayout animated:YES];
                 [self exposeEndedAtIndexPath:lastIndexPath exposed:NO];
             }
+            
+            // quick fix for iOS 6
+            if ([[UIDevice currentDevice].systemVersion floatValue] < 7) {
+                [self.collectionView reloadItemsAtIndexPaths:[self.collectionView indexPathsForVisibleItems]];
+            }
             [self.collectionView setContentOffset:self.stackedContentOffset animated:NO];
         }
         

--- a/TGLStackedViewController/TGLStackedViewController.m
+++ b/TGLStackedViewController/TGLStackedViewController.m
@@ -154,11 +154,16 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
             exposedLayout.maxTopVisibleItems = self.exposedMaxTopVisibleItems;
             exposedLayout.maxBottomVisibleItems = self.exposedMaxBottomVisibleItems;
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0
             [self.collectionView setCollectionViewLayout:exposedLayout animated:YES completion:^(BOOL finished) {
                 if (finished) {
                     [weakSelf exposeEndedAtIndexPath:exposedItemIndexPath exposed:YES];
                 }
             }];
+#else
+            [self.collectionView setCollectionViewLayout:exposedLayout animated:YES];
+            [self exposeEndedAtIndexPath:exposedItemIndexPath exposed:YES];
+#endif
             
         } else {
             NSIndexPath *lastIndexPath = _exposedItemIndexPath;
@@ -172,11 +177,16 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
             self.stackedLayout.overwriteContentOffset = YES;
             self.stackedLayout.contentOffset = self.stackedContentOffset;
             
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0
             [self.collectionView setCollectionViewLayout:self.stackedLayout animated:YES completion:^(BOOL finished) {
                 if (finished) {
                     [weakSelf exposeEndedAtIndexPath:lastIndexPath exposed:NO];
                 }
             }];
+#else
+            [self.collectionView setCollectionViewLayout:self.stackedLayout animated:YES];
+            [self exposeEndedAtIndexPath:lastIndexPath exposed:NO];
+#endif
             [self.collectionView setContentOffset:self.stackedContentOffset animated:NO];
         }
         

--- a/TGLStackedViewController/TGLStackedViewController.m
+++ b/TGLStackedViewController/TGLStackedViewController.m
@@ -100,7 +100,9 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
     _exposedLayoutMargin = UIEdgeInsetsMake(40.0, 0.0, 0.0, 0.0);
     _exposedItemSize = CGSizeZero;
     _exposedTopOverlap = 20.0;
+    _exposedMaxTopVisibleItems = 1;
     _exposedBottomOverlap = 20.0;
+    _exposedMaxBottomVisibleItems = 1;
     
     _movingCellOpaque = NO;
 }
@@ -146,6 +148,8 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
             exposedLayout.itemSize = self.exposedItemSize;
             exposedLayout.topOverlap = self.exposedTopOverlap;
             exposedLayout.bottomOverlap = self.exposedBottomOverlap;
+            exposedLayout.maxTopVisibleItems = self.exposedMaxTopVisibleItems;
+            exposedLayout.maxBottomVisibleItems = self.exposedMaxBottomVisibleItems;
 
             [self.collectionView setCollectionViewLayout:exposedLayout animated:YES];
             

--- a/TGLStackedViewController/TGLStackedViewController.m
+++ b/TGLStackedViewController/TGLStackedViewController.m
@@ -101,6 +101,8 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
     _exposedItemSize = CGSizeZero;
     _exposedTopOverlap = 20.0;
     _exposedBottomOverlap = 20.0;
+    
+    _movingCellOpaque = NO;
 }
 
 #pragma mark - View life cycle
@@ -494,7 +496,7 @@ typedef NS_ENUM(NSInteger, TGLStackedViewControllerScrollDirection) {
 
 - (UIImage *)screenshotImageOfItem:(UICollectionViewCell *)item {
     
-    UIGraphicsBeginImageContextWithOptions(item.bounds.size, item.isOpaque, 0.0f);
+    UIGraphicsBeginImageContextWithOptions(item.bounds.size, _movingCellOpaque, 0.0f);
     
     [item.layer renderInContext:UIGraphicsGetCurrentContext()];
     

--- a/TGLStackedViewExample/TGLTableViewController.m
+++ b/TGLStackedViewExample/TGLTableViewController.m
@@ -67,6 +67,8 @@
     if ([segue.identifier isEqualToString:@"Stand-alone (double tap to close)"]) {
         
         TGLViewController *controller = segue.destinationViewController;
+        controller.stackedLayout.topVisibleOverlappingHeight = 2.f;
+        controller.stackedLayout.maxTopVisibleOverlappingCards = 4;
         
         controller.doubleTapToClose = YES;
         

--- a/TGLStackedViewExample/TGLTableViewController.m
+++ b/TGLStackedViewExample/TGLTableViewController.m
@@ -68,7 +68,7 @@
         
         TGLViewController *controller = segue.destinationViewController;
         controller.stackedLayout.topVisibleOverlappingHeight = 2.f;
-        controller.stackedLayout.maxTopVisibleOverlappingCards = 4;
+        controller.stackedLayout.maxTopVisibleOverlappingCards = 3;
         
         controller.doubleTapToClose = YES;
         

--- a/TGLStackedViewExample/TGLTableViewController.m
+++ b/TGLStackedViewExample/TGLTableViewController.m
@@ -70,6 +70,10 @@
         controller.stackedLayout.topVisibleOverlappingHeight = 2.f;
         controller.stackedLayout.maxTopVisibleOverlappingCards = 3;
         
+        controller.exposedMaxTopVisibleItems = 0;
+        controller.exposedMaxBottomVisibleItems = 3;
+        controller.exposedBottomOverlap = 40;
+        
         controller.doubleTapToClose = YES;
         
     } else if ([segue.identifier isEqualToString:@"Show in NavigationController"]) {

--- a/TGLStackedViewExample/TGLViewController.m
+++ b/TGLStackedViewExample/TGLViewController.m
@@ -158,4 +158,16 @@
     [self.cards insertObject:card atIndex:toIndexPath.item];
 }
 
+- (void)exposeBeginAtIndexPath:(NSIndexPath *)indexPath exposed:(BOOL)exposed
+{
+    // before expose
+    NSLog(@"exposeBeginAtIndexPath:exposed:");
+}
+
+- (void)exposeEndedAtIndexPath:(NSIndexPath *)indexPath exposed:(BOOL)exposed
+{
+    // after expose
+    NSLog(@"exposeEndedAtIndexPath:exposed:");
+}
+
 @end


### PR DESCRIPTION
I found out that the background of moving cell is completely dark if the cell background set to `clearColor`.

![before](https://cloud.githubusercontent.com/assets/797182/4008022/2a5f2670-29d0-11e4-857c-a7a88dd7cc69.gif)

So I add a property to it.

![after](https://cloud.githubusercontent.com/assets/797182/4008030/585805f6-29d0-11e4-914a-11c2a9b979ad.gif)

And I also added stack feature on exposed layout

![exposed layout stack feature](https://cloud.githubusercontent.com/assets/797182/4026222/e4433750-2c11-11e4-846b-9e7f200920e6.png)