### PR TITLE
Added handler for changing exposed item (exposed item index path)

### DIFF
--- a/TGLStackedViewController/TGLStackedViewController.h
+++ b/TGLStackedViewController/TGLStackedViewController.h
@@ -158,6 +158,14 @@ FOUNDATION_EXPORT const unsigned char TGLStackedViewControllerVersionString[];
  */
 @property (nonatomic, strong, nullable) NSIndexPath *exposedItemIndexPath;
 
+/**
+ * exposedItemIndexPath change handler
+ * @param oldVal The old value of exposedItemIndexPath. Can be Null - was stackedLayout
+ * @param newVal New value of exposedItemIndexPath. Can be Null - will be stackedLayout
+ */
+@property (nonatomic, copy) void (^ _Nullable exposedItemIndexPathHandler)(NSIndexPath * _Nullable oldVal, NSIndexPath * _Nullable newVal);
+
+
 /** Allow exposed items to be interactively collapsed by a gesture.
  *
  * If `-exposedPinningMode` is set to `TGLExposedLayoutPinningModeNone`

--- a/TGLStackedViewController/TGLStackedViewController.m
+++ b/TGLStackedViewController/TGLStackedViewController.m
@@ -214,6 +214,10 @@
             self.stackedLayout.overwriteContentOffset = YES;
             self.exposedLayout = exposedLayout;
 
+            if (self.exposedItemIndexPathHandler != NULL) {
+                self.exposedItemIndexPathHandler(self->_exposedItemIndexPath, exposedItemIndexPath);
+            }
+            // Mention self explicitly here to get rid of compiler warning
             self->_exposedItemIndexPath = exposedItemIndexPath;
 
             UICollectionViewCell *exposedCell = [self.collectionView cellForItemAtIndexPath:self.exposedItemIndexPath];
@@ -265,6 +269,9 @@
             //       `layoutcompletion` goes out of scope.
             self.exposedLayout = exposedLayout;
 
+            if (self.exposedItemIndexPathHandler != NULL) {
+                self.exposedItemIndexPathHandler(self->_exposedItemIndexPath, exposedItemIndexPath);
+            }
             // Mention self explicitly here to get rid of compiler warning
             self->_exposedItemIndexPath = exposedItemIndexPath;
             
@@ -305,6 +312,9 @@
         
         self.exposedLayout = nil;
         
+        if (self.exposedItemIndexPathHandler != NULL) {
+            self.exposedItemIndexPathHandler(_exposedItemIndexPath, exposedItemIndexPath);
+        }
         _exposedItemIndexPath = nil;
         
         void (^layoutcompletion) (BOOL) = ^ (BOOL finished) {
@@ -340,8 +350,12 @@
 
     // Set -exposedItemIndexPath to `nil` w/o triggering
     // any layout updates as in the setters above
-    //
-    _exposedItemIndexPath = nil;
+    
+    if (self.exposedItemIndexPathHandler != NULL) {
+        self.exposedItemIndexPathHandler(self.exposedItemIndexPath, nil);
+    }
+     _exposedItemIndexPath = nil;
+    
 }
 
 #pragma mark - Actions


### PR DESCRIPTION
I've added a change handler for exposedItemIndexPath. It will allow tracking exposed Item IndexPath changes. Especially when we close exposed item by swipe gesture.